### PR TITLE
Ajout d'un fichier .gitignore

### DIFF
--- a/Linux/.gitignore
+++ b/Linux/.gitignore
@@ -1,1 +1,10 @@
-
+# Ignorer les fichiers intermédiaires
+*.aux
+*.log
+*.out
+# Ignorer le fichier local de navigation
+*.synctex.gz
+# Ignorer le fichier généré
+*.pdf
+# Ignorer le répertoire de travail de Minted
+/_minted-howto/*


### PR DESCRIPTION
Ajout d'un fichier .gitignore pour enlever les fichiers intermédiaires, le fichier généré, et le fichiers utilisé seulement localement pour la navigation.